### PR TITLE
feat(shopee): enrich chat product cards and fix get_item_base_info

### DIFF
--- a/app/(main)/chats/[id]/page.tsx
+++ b/app/(main)/chats/[id]/page.tsx
@@ -57,7 +57,13 @@ type Message = {
   content: string;
   time: string;
   content_kind?: MessageContentKind;
-  item_card?: { item_id?: string; name?: string; image_url?: string; shop_id?: string };
+  item_card?: {
+    item_id?: string;
+    name?: string;
+    image_url?: string;
+    shop_id?: string;
+    related_order_sn?: string;
+  };
   order_card?: { order_sn?: string };
   sticker_card?: { image_url?: string; sticker_id?: string; package_id?: string };
   image_card?: { url?: string };
@@ -110,7 +116,7 @@ function ChatMessageBody({ msg, isStaff }: { msg: Message; isStaff: boolean }) {
           {msg.item_card?.image_url ? (
             <img
               src={msg.item_card.image_url}
-              alt=""
+              alt={msg.item_card?.name?.trim() || "商品"}
               className="w-16 h-16 rounded-md object-cover shrink-0 border border-black/10"
             />
           ) : null}
@@ -121,6 +127,11 @@ function ChatMessageBody({ msg, isStaff }: { msg: Message; isStaff: boolean }) {
             </p>
             {msg.item_card?.item_id ? (
               <p className="text-[10px] opacity-70 mt-1 tabular-nums">ID: {msg.item_card.item_id}</p>
+            ) : null}
+            {msg.item_card?.related_order_sn ? (
+              <p className="text-[10px] opacity-70 mt-1 font-mono break-all">
+                関連注文: {msg.item_card.related_order_sn}
+              </p>
             ) : null}
             {msg.item_url ? (
               <a
@@ -385,6 +396,8 @@ export default function ChatDetailPage() {
   const lastMessageCountRef = useRef(0);
   /** テンプレ選択直後の ID（送信時に本文一致なら「テンプレ」扱い） */
   const pendingTemplateIdRef = useRef<string | null>(null);
+  /** 連打で同一メッセージが複数送信されるのを防ぐ（setState より先に同期ガード） */
+  const sendLockRef = useRef(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [stickerPickerOpen, setStickerPickerOpen] = useState(false);
 
@@ -428,6 +441,35 @@ export default function ChatDetailPage() {
           image_url: c?.image_url,
         });
       }
+    }
+    return Array.from(m.values());
+  }, [messages]);
+
+  /** 会話メッセージから商品カードを集約（未注文の問い合わせでもサイドで確認できるように） */
+  const relatedProductsFromChat = useMemo(() => {
+    const m = new Map<
+      string,
+      {
+        item_id?: string;
+        name: string;
+        image_url?: string;
+        item_url?: string;
+      }
+    >();
+    for (const msg of messages) {
+      if (msg.content_kind !== "item") continue;
+      const card = msg.item_card;
+      const id = card?.item_id?.trim();
+      const name = (card?.name ?? msg.content ?? "").trim();
+      if (!id && !name) continue;
+      const key = id || `name:${name}`;
+      if (m.has(key)) continue;
+      m.set(key, {
+        ...(id ? { item_id: id } : {}),
+        name: name || "商品",
+        image_url: card?.image_url,
+        item_url: msg.item_url,
+      });
     }
     return Array.from(m.values());
   }, [messages]);
@@ -653,6 +695,8 @@ export default function ChatDetailPage() {
     stickerPackageId: string,
     stickerRowId: string
   ) => {
+    if (sendLockRef.current || sending) return;
+    sendLockRef.current = true;
     setSending(true);
     try {
       const res = await fetch(`/api/chats/${encodeURIComponent(id)}/send`, {
@@ -699,11 +743,13 @@ export default function ChatDetailPage() {
         error instanceof Error ? error.message : "スタンプの送信に失敗しました"
       );
     } finally {
+      sendLockRef.current = false;
       setSending(false);
     }
   };
 
   const handleSend = async () => {
+    if (sendLockRef.current || sending) return;
     if (!inputMessage.trim() && attachedFiles.length === 0) return;
 
     const tplId = pendingTemplateIdRef.current;
@@ -716,6 +762,7 @@ export default function ChatDetailPage() {
       inputMessage.trim() === tplRow.content.trim();
     const staffSendKind: StaffSendKind = isTplSend ? "template" : "manual";
 
+    sendLockRef.current = true;
     setSending(true);
     try {
       const res = await fetch(`/api/chats/${encodeURIComponent(id)}/send`, {
@@ -755,6 +802,7 @@ export default function ChatDetailPage() {
       console.error("Send error:", error);
       toast.error(error instanceof Error ? error.message : "送信に失敗しました");
     } finally {
+      sendLockRef.current = false;
       setSending(false);
     }
   };
@@ -858,6 +906,63 @@ export default function ChatDetailPage() {
             </div>
           </div>
 
+          {relatedProductsFromChat.length > 0 ? (
+            <div className="bg-card rounded-xl border border-border shadow-card p-4 space-y-2">
+              <div className="flex items-center gap-2 pb-1 border-b border-border">
+                <ShoppingBag size={14} className="text-primary" />
+                <p className="text-foreground font-semibold text-sm">
+                  関連商品（チャット）
+                </p>
+              </div>
+              <TooltipProvider delayDuration={250}>
+                <ul className="space-y-2 max-h-[min(36vh,280px)] overflow-y-auto scrollbar-thin">
+                  {relatedProductsFromChat.map((p, i) => (
+                    <li
+                      key={p.item_id ?? `n-${i}-${p.name}`}
+                      className="rounded-lg border border-border bg-muted/30 px-2.5 py-2 text-xs"
+                    >
+                      <div className="flex gap-2 items-start min-w-0">
+                        {p.image_url ? (
+                          <img
+                            src={p.image_url}
+                            alt=""
+                            className="w-10 h-10 rounded-md object-cover shrink-0 border border-border"
+                            loading="lazy"
+                            referrerPolicy="no-referrer"
+                            onError={(e) => {
+                              e.currentTarget.style.display = "none";
+                            }}
+                          />
+                        ) : null}
+                        <div className="min-w-0 flex-1">
+                          <p className="text-foreground font-medium line-clamp-3 leading-snug">
+                            {p.name}
+                          </p>
+                          {p.item_id ? (
+                            <p className="text-[10px] text-muted-foreground mt-0.5 tabular-nums">
+                              ID: {p.item_id}
+                            </p>
+                          ) : null}
+                          {p.item_url ? (
+                            <a
+                              href={p.item_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary font-medium mt-1 hover:underline"
+                            >
+                              商品ページ
+                              <ExternalLink size={12} className="shrink-0" />
+                            </a>
+                          ) : null}
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </TooltipProvider>
+            </div>
+          ) : null}
+
           <div className="bg-card rounded-xl border border-border shadow-card p-4 space-y-2">
             <div className="flex items-center gap-2 pb-1 border-b border-border">
               <Package size={14} className="text-primary" />
@@ -870,7 +975,18 @@ export default function ChatDetailPage() {
               </div>
             ) : orders.length === 0 ? (
               <p className="text-xs text-muted-foreground leading-relaxed">
-                チャットまたは直近90日の注文一覧から該当する注文が見つかりませんでした。
+                直近90日の注文一覧から該当する注文が見つかりませんでした。
+                {relatedProductsFromChat.length > 0 ? (
+                  <>
+                    {" "}
+                    上の「関連商品」またはメッセージ内の商品カードをご確認ください。
+                  </>
+                ) : (
+                  <>
+                    {" "}
+                    未購入のお問い合わせの場合は、メッセージ内の商品カードが表示されます。
+                  </>
+                )}
               </p>
             ) : (
               <TooltipProvider delayDuration={250}>
@@ -1421,17 +1537,21 @@ export default function ChatDetailPage() {
               placeholder="メッセージを入力..."
               value={inputMessage}
               onChange={e => setInputMessage(e.target.value)}
+              disabled={sending}
               className="resize-none text-sm min-h-[72px] min-w-0 flex-1"
               onKeyDown={e => {
                 if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
-                  handleSend();
+                  if (!sending) void handleSend();
                 }
               }}
             />
             <Button
-              onClick={handleSend}
-              className="gradient-primary text-primary-foreground shadow-green self-end h-10 sm:h-10 px-4 min-h-[44px] flex-shrink-0 gap-2"
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={sending}
+              aria-busy={sending}
+              className="gradient-primary text-primary-foreground shadow-green self-end h-10 sm:h-10 px-4 min-h-[44px] flex-shrink-0 gap-2 disabled:opacity-60"
             >
               <Send size={14} />
             </Button>

--- a/app/api/chats/[id]/messages/route.ts
+++ b/app/api/chats/[id]/messages/route.ts
@@ -15,6 +15,7 @@ import {
   shopeeMessageTimeToMs,
 } from "@/lib/shopee-conversation-utils";
 import { buildBuyerItemUrl, buildSellerOrderUrl } from "@/lib/shopee-order-utils";
+import { fetchItemCatalogMapByIds } from "@/lib/shopee-product-utils";
 import { kindMapFromLog } from "@/lib/staff-message-kind";
 import { getStoredRawMessagesForConversation } from "@/lib/shopee-conversation-db-sync";
 
@@ -66,20 +67,32 @@ export async function GET(
       conversation.customer_avatar_url ?? null;
     let shopLogo: string | null = null;
 
+    /** Webhook が書いたキャッシュ。API 失敗時のみフォールバックに使う。 */
     const storedRaws = await getStoredRawMessagesForConversation(
       conversation.shop_id,
       conversationId
     );
 
     const [msgResult, oneRes, shopRes] = await Promise.allSettled([
-      storedRaws.length > 0
-        ? Promise.resolve(storedRaws)
-        : fetchAllConversationMessages(
+      (async () => {
+        try {
+          return await fetchAllConversationMessages(
             accessToken,
             conversation.shop_id,
             conversationId,
             countryOpt
-          ),
+          );
+        } catch (err) {
+          if (storedRaws.length > 0) {
+            console.warn(
+              "[messages] fetchAllConversationMessages failed; using MongoDB cache",
+              err
+            );
+            return storedRaws;
+          }
+          throw err;
+        }
+      })(),
       getOneConversation(
         accessToken,
         conversation.shop_id,
@@ -155,11 +168,15 @@ export async function GET(
           ? buildSellerOrderUrl(countryResolved, orderSn)
           : undefined;
       const item = display.item;
+      const shopIdForLink =
+        item?.shop_id != null && String(item.shop_id).trim() !== ""
+          ? String(item.shop_id)
+          : String(conversation.shop_id);
       const item_url =
-        item?.item_id && item?.shop_id
+        item?.item_id && shopIdForLink
           ? buildBuyerItemUrl(
               countryResolved,
-              item.shop_id,
+              shopIdForLink,
               item.item_id
             )
           : undefined;
@@ -202,6 +219,34 @@ export async function GET(
         staff_send_kind,
       };
     });
+
+    const itemIdsForCatalog = messages
+      .filter((m) => m.content_kind === "item" && m.item_card?.item_id)
+      .map((m) => Number(m.item_card!.item_id))
+      .filter((n) => Number.isFinite(n) && n > 0);
+
+    if (itemIdsForCatalog.length > 0) {
+      const catalog = await fetchItemCatalogMapByIds(
+        accessToken,
+        conversation.shop_id,
+        itemIdsForCatalog,
+        countryOpt
+      );
+      for (const m of messages) {
+        if (m.content_kind !== "item" || !m.item_card?.item_id) continue;
+        const n = Number(m.item_card.item_id);
+        const info = catalog.get(n);
+        if (!info) continue;
+        m.item_card = {
+          ...m.item_card,
+          name: info.name || m.item_card.name,
+          image_url: info.image_url || m.item_card.image_url,
+        };
+        if (m.item_card.name) {
+          m.content = `商品: ${m.item_card.name}`;
+        }
+      }
+    }
 
     messages.sort((a, b) => a.timestamp_ms - b.timestamp_ms);
 

--- a/src/lib/shopee-api.ts
+++ b/src/lib/shopee-api.ts
@@ -242,6 +242,60 @@ export async function getShopNotification(
   return data;
 }
 
+const ITEM_BASE_INFO_MAX_IDS = 50;
+
+/**
+ * 商品マスタ（チャットの item_id から商品名・メイン画像を補完する）
+ *
+ * 公式は **GET**（クエリに `item_id_list`）。POST は環境によって 404 / 非対応になることがある。
+ * @see https://open.shopee.com/documents/v2/v2.product.get_item_base_info?module=89&type=1
+ */
+export async function getItemBaseInfo(
+  accessToken: string,
+  shopId: number,
+  itemIdList: number[],
+  options?: ShopeeApiOptions
+): Promise<Record<string, unknown>> {
+  const path = "/api/v2/product/get_item_base_info";
+  const timestamp = Math.floor(Date.now() / 1000);
+  const sign = generateSignature(path, timestamp, accessToken, shopId);
+  const base = getShopeeBaseUrl(options?.country);
+
+  const ids = itemIdList
+    .map((n) => Math.floor(Number(n)))
+    .filter((n) => Number.isFinite(n) && n > 0)
+    .slice(0, ITEM_BASE_INFO_MAX_IDS);
+
+  if (ids.length === 0) {
+    return { response: { item_list: [] } };
+  }
+
+  /** GET の `item_id_list` は JSON 配列文字列ではなく **カンマ区切り**（`order_sn_list` と同様）。`[123]` だと strconv.ParseUint が失敗する */
+  const itemIdListParam = encodeURIComponent(ids.join(","));
+
+  const url =
+    `${base}${path}?` +
+    `partner_id=${PARTNER_ID}&` +
+    `timestamp=${timestamp}&` +
+    `access_token=${encodeURIComponent(accessToken)}&` +
+    `shop_id=${shopId}&` +
+    `sign=${sign}` +
+    `&item_id_list=${itemIdListParam}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const data = await parseShopeeResponseJson(response, "get_item_base_info");
+
+  if (data.error) {
+    throw new Error(`Shopee API Error: ${String(data.message ?? data.error)}`);
+  }
+
+  return data;
+}
+
 /**
  * Get seller chat conversations list
  *

--- a/src/lib/shopee-conversation-utils.ts
+++ b/src/lib/shopee-conversation-utils.ts
@@ -168,6 +168,8 @@ export type ShopeeMessageDisplay = {
     name?: string;
     image_url?: string;
     shop_id?: string;
+    /** 注文カードではなく商品を出すとき、紐づく注文があれば補足表示用 */
+    related_order_sn?: string;
   };
   order?: { order_sn?: string };
   sticker?: {
@@ -199,6 +201,38 @@ function absorbJsonObject(target: Record<string, unknown>, raw: unknown): void {
   }
 }
 
+function assignIfObject(
+  flat: Record<string, unknown>,
+  raw: unknown
+): void {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    Object.assign(flat, raw as Record<string, unknown>);
+  }
+}
+
+/**
+ * Shopee は商品カードを `content.item` / `item_card` 等にネストして返すことがある。
+ * ルート直下の `item` だけでは item_id が取れないため、ネストをフラットに寄せる。
+ */
+function mergeNestedItemLikeIntoFlat(
+  flat: Record<string, unknown>,
+  obj: unknown,
+  depth: number
+): void {
+  if (depth <= 0 || obj == null || typeof obj !== "object" || Array.isArray(obj)) return;
+  const o = obj as Record<string, unknown>;
+  for (const key of [
+    "item",
+    "item_card",
+    "item_info",
+    "product",
+    "product_card",
+    "goods",
+  ]) {
+    assignIfObject(flat, o[key]);
+  }
+}
+
 /** message / content をフラット化（JSON 文字列も展開）してキー検索しやすくする */
 export function flattenShopeeChatPayload(msg: Record<string, unknown>): Record<string, unknown> {
   const flat: Record<string, unknown> = { ...msg };
@@ -208,15 +242,38 @@ export function flattenShopeeChatPayload(msg: Record<string, unknown>): Record<s
   if (item && typeof item === "object" && !Array.isArray(item)) {
     Object.assign(flat, item as Record<string, unknown>);
   }
+  assignIfObject(flat, msg.item_card);
+  assignIfObject(flat, msg.item_info);
+  assignIfObject(flat, msg.product);
+  mergeNestedItemLikeIntoFlat(flat, msg.message, 2);
+  mergeNestedItemLikeIntoFlat(flat, msg.content, 2);
   const sticker = msg.sticker;
   if (sticker && typeof sticker === "object" && !Array.isArray(sticker)) {
     Object.assign(flat, sticker as Record<string, unknown>);
   }
   const order = msg.order;
   if (order && typeof order === "object" && !Array.isArray(order)) {
-    Object.assign(flat, order as Record<string, unknown>);
+    const orec = order as Record<string, unknown>;
+    Object.assign(flat, orec);
+    const il = orec.item_list;
+    if (Array.isArray(il) && il.length > 0 && il[0] && typeof il[0] === "object") {
+      Object.assign(flat, il[0] as Record<string, unknown>);
+    }
   }
   return flat;
+}
+
+/** 本文・リンクに含まれる Shopee 商品 URL から item_id / shop_id を拾う */
+function extractProductIdsFromText(text: string | undefined): {
+  shop_id?: string;
+  item_id?: string;
+} {
+  if (!text || !text.trim()) return {};
+  const m = text.match(/\/product\/(\d+)\/(\d+)/);
+  if (m) {
+    return { shop_id: m[1], item_id: m[2] };
+  }
+  return {};
 }
 
 function findOrderSnDeep(obj: unknown): string | undefined {
@@ -282,6 +339,28 @@ function pickImageUrlFromPayload(
     const v = flat[k];
     if (typeof v === "string" && /^https?:\/\//i.test(v)) return v;
   }
+  const ii = flat.image_info;
+  if (ii && typeof ii === "object" && !Array.isArray(ii)) {
+    const io = ii as Record<string, unknown>;
+    const list = io.image_url_list;
+    if (Array.isArray(list) && list[0] && typeof list[0] === "string") {
+      const u = list[0].trim();
+      if (/^https?:\/\//i.test(u)) return u;
+    }
+    const single = io.image_url ?? io.thumbnail_url;
+    if (typeof single === "string" && /^https?:\/\//i.test(single)) return single;
+  }
+  const imgBlock = flat.image;
+  if (imgBlock && typeof imgBlock === "object" && !Array.isArray(imgBlock)) {
+    const io = imgBlock as Record<string, unknown>;
+    const list = io.image_url_list;
+    if (Array.isArray(list) && list[0] && typeof list[0] === "string") {
+      const u = list[0].trim();
+      if (/^https?:\/\//i.test(u)) return u;
+    }
+    const single = io.image_url ?? io.thumbnail_url;
+    if (typeof single === "string" && /^https?:\/\//i.test(single)) return single;
+  }
   const walkUrls = (o: unknown): string[] => {
     const out: string[] = [];
     const w = (x: unknown) => {
@@ -330,16 +409,34 @@ export function displayFromShopeeChatMessage(msg: Record<string, unknown>): Shop
     return undefined;
   };
 
-  let orderSn = pickString(flat, ["order_sn", "ordersn"]);
+  const explicitOrderSn = pickString(flat, ["order_sn", "ordersn"]);
+  let orderSn = explicitOrderSn;
   if (!orderSn && (mt.includes("order") || mt.includes("notification"))) {
     orderSn = findOrderSnDeep(flat) ?? findOrderSnDeep(msg);
   }
 
-  const itemId = pickString(flat, ["item_id", "itemid", "item_id_str", "itemid_str"]);
-  const itemName = pickString(flat, ["item_name", "name", "item_title", "title", "product_name"]);
+  let resolvedItemId = pickString(flat, [
+    "item_id",
+    "itemid",
+    "item_id_str",
+    "itemid_str",
+  ]);
+  const itemName = pickString(flat, [
+    "item_name",
+    "name",
+    "item_title",
+    "title",
+    "product_name",
+    "product_title",
+  ]);
+  let resolvedShopId = pickString(flat, ["shop_id", "shopid"]);
+  const textBlob = [plainTextEarly(), pickString(flat, ["text"])].filter(Boolean).join("\n");
+  const fromUrl = extractProductIdsFromText(textBlob);
+  if (!resolvedItemId && fromUrl.item_id) resolvedItemId = fromUrl.item_id;
+  if (!resolvedShopId && fromUrl.shop_id) resolvedShopId = fromUrl.shop_id;
+
   const itemNameResolved =
     itemName || (mt.includes("item") ? pickString(flat, ["text"]) : undefined);
-  const shopId = pickString(flat, ["shop_id", "shopid"]);
   const img = pickImageUrlFromPayload(flat, msg, mt);
 
   /** message_type が数値や別名でも、sticker 系フィールドがあればスタンプとして扱う */
@@ -363,28 +460,51 @@ export function displayFromShopeeChatMessage(msg: Record<string, unknown>): Shop
     };
   }
 
+  /**
+   * 注文カードより商品カードを優先（未購入の問い合わせでは注文番号より商品が重要）
+   */
+  const looksLikeProductMessage =
+    mt.includes("item") ||
+    mt.includes("item_card") ||
+    mt.includes("product") ||
+    mt.includes("product_card") ||
+    mt.includes("inquiry") ||
+    mt.includes("listing") ||
+    !!resolvedItemId ||
+    !!itemName ||
+    !!itemNameResolved;
+
+  /** 商品を主表示にしつつ、注文文脈が明確なときだけ注文番号を補足する */
+  const showRelatedOrderSn =
+    !!orderSn &&
+    (!!explicitOrderSn ||
+      mt.includes("order_notification") ||
+      mt.includes("order_card") ||
+      (mt.includes("order") && mt.includes("notification")));
+
+  if (looksLikeProductMessage) {
+    return {
+      kind: "item",
+      summary: itemNameResolved
+        ? `商品: ${itemNameResolved}`
+        : resolvedItemId
+          ? `商品 (item_id: ${resolvedItemId})`
+          : "商品",
+      item: {
+        item_id: resolvedItemId,
+        name: itemNameResolved,
+        image_url: img,
+        shop_id: resolvedShopId,
+        ...(showRelatedOrderSn ? { related_order_sn: orderSn } : {}),
+      },
+    };
+  }
+
   if (mt.includes("order") || mt.includes("order_notification") || orderSn) {
     return {
       kind: "order",
       summary: orderSn ? `注文番号: ${orderSn}` : "注文情報",
       order: { order_sn: orderSn },
-    };
-  }
-
-  if (mt.includes("item") || itemId || itemNameResolved || itemName) {
-    return {
-      kind: "item",
-      summary: itemNameResolved
-        ? `商品: ${itemNameResolved}`
-        : itemId
-          ? `商品 (item_id: ${itemId})`
-          : "商品",
-      item: {
-        item_id: itemId,
-        name: itemNameResolved,
-        image_url: img,
-        shop_id: shopId,
-      },
     };
   }
 

--- a/src/lib/shopee-order-utils.ts
+++ b/src/lib/shopee-order-utils.ts
@@ -122,5 +122,21 @@ export function pickOrderItemImageUrl(
     }
   }
 
+  /** `get_item_base_info` 等は `image.image_url_list` を返す */
+  const im = item.image;
+  if (im && typeof im === "object" && !Array.isArray(im)) {
+    const o = im as Record<string, unknown>;
+    const fromNested =
+      http(o.image_url) ?? http(o.thumbnail_url) ?? http(o.url);
+    if (fromNested) return fromNested;
+    const list = o.image_url_list;
+    if (Array.isArray(list)) {
+      for (const u of list) {
+        const s = http(u);
+        if (s) return s;
+      }
+    }
+  }
+
   return undefined;
 }

--- a/src/lib/shopee-product-utils.ts
+++ b/src/lib/shopee-product-utils.ts
@@ -1,0 +1,54 @@
+import { getItemBaseInfo, type ShopeeApiOptions } from "./shopee-api";
+import { pickOrderItemImageUrl } from "./shopee-order-utils";
+
+export type ItemCatalogEntry = { name?: string; image_url?: string };
+
+/** `get_item_base_info` のレスポンスから item_id → 表示用フィールド */
+export function itemCatalogMapFromItemBaseInfoResponse(
+  data: Record<string, unknown>
+): Map<number, ItemCatalogEntry> {
+  const map = new Map<number, ItemCatalogEntry>();
+  const r = data.response as Record<string, unknown> | undefined;
+  const list = (r?.item_list ?? r?.items ?? []) as unknown[];
+  if (!Array.isArray(list)) return map;
+  for (const raw of list) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const it = raw as Record<string, unknown>;
+    const n = Number(it.item_id);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    const nameRaw = it.item_name;
+    const name =
+      typeof nameRaw === "string" && nameRaw.trim().length > 0
+        ? nameRaw.trim()
+        : undefined;
+    const image_url = pickOrderItemImageUrl(it);
+    map.set(n, { name, image_url });
+  }
+  return map;
+}
+
+/**
+ * 会話内の item_id 一覧から商品名・画像をまとめて取得（50 件ずつ）
+ */
+export async function fetchItemCatalogMapByIds(
+  accessToken: string,
+  shopId: number,
+  itemIds: number[],
+  options?: ShopeeApiOptions
+): Promise<Map<number, ItemCatalogEntry>> {
+  const out = new Map<number, ItemCatalogEntry>();
+  const uniq = [...new Set(itemIds.map((n) => Math.floor(Number(n))))].filter(
+    (n) => Number.isFinite(n) && n > 0
+  );
+  for (let i = 0; i < uniq.length; i += 50) {
+    const chunk = uniq.slice(i, i + 50);
+    try {
+      const data = await getItemBaseInfo(accessToken, shopId, chunk, options);
+      const m = itemCatalogMapFromItemBaseInfoResponse(data);
+      for (const [k, v] of m) out.set(k, v);
+    } catch (e) {
+      console.warn("[fetchItemCatalogMapByIds] get_item_base_info failed", e);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Chat messages that reference a product now prefer item display over bare order info: flatten order.item_list into the parsed payload, read item/shop IDs from in-app product URLs, and optionally show a related order number when the context is clearly order-related.

The messages API batches v2.product.get_item_base_info (GET) to fill product name and main image when the sellerchat payload is thin. Shopee expects item_id_list as comma-separated IDs on the query string; a JSON array literal caused parse errors on their side.

Also parse image fields from nested image blocks (including get_item_base_info), extend order-item image extraction for the product image object, and improve the product card image alt text in the chat UI.

Made-with: Cursor