### PR TITLE
fix(chats): track last_buyer_message_time for accurate elapsed and au…

### DIFF
--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -31,6 +31,7 @@ export async function GET(request: NextRequest) {
       customer_name: string;
       last_message: string;
       last_message_time: Date;
+      last_buyer_message_time?: Date;
       last_message_type?: string;
       chat_type?: ChatType;
       unread_count: number;
@@ -50,6 +51,7 @@ export async function GET(request: NextRequest) {
       customer_name: string;
       last_message: string;
       last_message_time: Date;
+      last_buyer_message_time?: Date;
       last_message_type?: string;
       chat_type?: ChatType;
       unread_count: number;
@@ -103,8 +105,9 @@ export async function GET(request: NextRequest) {
 
     const now = Date.now();
     let chats = conversations.map((conv) => {
-      const elapsed =
-        (now - conv.last_message_time.getTime()) / (1000 * 60 * 60);
+      // バイヤーの最新メッセージ時刻を基準にする（スタッフ返信時刻は除外）
+      const elapsedBase = conv.last_buyer_message_time ?? conv.last_message_time;
+      const elapsed = (now - elapsedBase.getTime()) / (1000 * 60 * 60);
 
       const uiStatus =
         conv.status === "archived"

--- a/app/api/shopee/webhook/route.ts
+++ b/app/api/shopee/webhook/route.ts
@@ -109,6 +109,7 @@ async function handleNewMessage(data: Record<string, unknown>) {
       to_id: toId,
       to_name: toName,
       from_id: fromId,
+      last_buyer_message_time: hint.last_buyer_message_time,
     });
   } catch (error) {
     console.error("[Webhook] handleNewMessage error:", error);

--- a/src/lib/auto-reply.ts
+++ b/src/lib/auto-reply.ts
@@ -157,6 +157,8 @@ type WebhookMsg = {
   to_id: number;
   to_name: string;
   from_id: number;
+  /** バイヤーの最新メッセージ受信時刻（DBに記録済みの値）。未指定なら Date.now() を使用 */
+  last_buyer_message_time?: Date;
 };
 
 /**
@@ -198,7 +200,9 @@ export async function handleAutoReplyOnWebhookMessage(
   if (!ObjectId.isValid(cfg.template_id.trim())) return;
 
   const triggerHour = Math.max(1, Number(cfg.triggerHour) || 1);
-  const due = new Date(Date.now() + triggerHour * 60 * 60 * 1000);
+  // バイヤーの最新メッセージ時刻を基準に due を計算（Webhook遅延があっても正確）
+  const baseTime = data.last_buyer_message_time?.getTime() ?? Date.now();
+  const due = new Date(baseTime + triggerHour * 60 * 60 * 1000);
 
   await col.updateOne(
     { conversation_id: convId, shop_id },
@@ -212,7 +216,7 @@ export async function handleAutoReplyOnWebhookMessage(
   );
 
   console.log(
-    `[auto-reply] Scheduled for ${convId} shop=${shop_id} due=${due.toISOString()} (${triggerHour}h)`
+    `[auto-reply] Scheduled for ${convId} shop=${shop_id} due=${due.toISOString()} (${triggerHour}h from ${data.last_buyer_message_time?.toISOString() ?? "now"})`
   );
 }
 

--- a/src/lib/shopee-conversation-db-sync.ts
+++ b/src/lib/shopee-conversation-db-sync.ts
@@ -49,6 +49,18 @@ function pickLatestMessage(
   return best;
 }
 
+/** バイヤー（shopId 以外が送信）のメッセージの中で最新のものを返す */
+function pickLatestBuyerMessage(
+  rawList: Record<string, unknown>[],
+  shopId: number
+): Record<string, unknown> | undefined {
+  const buyerMsgs = rawList.filter((m) => {
+    const fromId = Number(m.from_id ?? m.from_user_id ?? 0);
+    return fromId !== shopId;
+  });
+  return pickLatestMessage(buyerMsgs);
+}
+
 /**
  * Webhook（code 10）後: Shopee から全メッセージ + 会話1件を取得し、
  * - `shopee_chat_messages` に upsert
@@ -68,6 +80,7 @@ export async function syncWebhookConversationFull(
     to_id: number;
     to_name: string;
     from_id: number;
+    last_buyer_message_time?: Date;
   };
 }> {
   try {
@@ -148,6 +161,15 @@ export async function syncWebhookConversationFull(
         )
       : new Date();
 
+    const latestBuyer = pickLatestBuyerMessage(rawList, shopId);
+    const lastBuyerTime = latestBuyer
+      ? new Date(
+          shopeeMessageTimeToMs(
+            latestBuyer.timestamp ?? latestBuyer.created_timestamp ?? latestBuyer.time
+          )
+        )
+      : undefined;
+
     const convCol = await getCollection<{
       conversation_id: string;
       shop_id: number;
@@ -156,6 +178,7 @@ export async function syncWebhookConversationFull(
       customer_name: string;
       last_message: string;
       last_message_time: Date;
+      last_buyer_message_time?: Date;
       unread_count: number;
       status: string;
       customer_avatar_url?: string;
@@ -167,6 +190,7 @@ export async function syncWebhookConversationFull(
       last_message: lastPreview || "",
       last_message_time: lastTime,
     };
+    if (lastBuyerTime) setConv.last_buyer_message_time = lastBuyerTime;
     if (country) setConv.country = country;
     if (Number.isFinite(buyerId) && buyerId > 0) setConv.customer_id = buyerId;
     if (buyerName) setConv.customer_name = buyerName;
@@ -201,6 +225,7 @@ export async function syncWebhookConversationFull(
         to_name: buyerName,
         /** 最新メッセージの送信元（Webhook の data が欠けるときの代替） */
         from_id: Number.isFinite(latestFromId) ? latestFromId : 0,
+        last_buyer_message_time: lastBuyerTime,
       },
     };
   } catch (e) {


### PR DESCRIPTION
…to-reply timing

Previously, elapsed time and auto-reply scheduling were based on last_message_time, which includes staff replies. This caused elapsed to reset to zero after a staff reply and auto-reply due_at to be calculated from the wrong baseline when a buyer sent follow-up messages.

- Add pickLatestBuyerMessage() to isolate buyer-only messages by from_id
- Set last_buyer_message_time in syncWebhookConversationFull and propagate via autoReplyHint to handleAutoReplyOnWebhookMessage
- Calculate elapsed in GET /api/chats from last_buyer_message_time (falls back to last_message_time for legacy docs without the field)
- Base auto_reply_due_at on last_buyer_message_time so trigger fires at exactly configured hours after the buyer's message, not webhook arrival