### PR TITLE
fix(chats): align date/time display with last_buyer_message_time

### DIFF
--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -126,12 +126,12 @@ export async function GET(request: NextRequest) {
         customer_id: conv.customer_id,
         lastMessage: conv.last_message,
         product: "—",
-        date: conv.last_message_time.toLocaleDateString("ja-JP", {
+        date: elapsedBase.toLocaleDateString("ja-JP", {
           year: "numeric",
           month: "2-digit",
           day: "2-digit",
         }),
-        time: conv.last_message_time.toLocaleTimeString("ja-JP", {
+        time: elapsedBase.toLocaleTimeString("ja-JP", {
           hour: "2-digit",
           minute: "2-digit",
         }),


### PR DESCRIPTION
date and time columns were still using last_message_time (which includes staff replies), while elapsed already used last_buyer_message_time. This caused the displayed timestamp to show the staff reply time while elapsed showed hours since the buyer's message — visually inconsistent.

Use elapsedBase (last_buyer_message_time ?? last_message_time) for both the date/time columns and elapsed so all three fields point to the same reference moment.