### PR TITLE
fix(timezone): explicitly set Asia/Tokyo on all date formatting calls

### DIFF
--- a/app/(main)/chats/[id]/page.tsx
+++ b/app/(main)/chats/[id]/page.tsx
@@ -200,15 +200,21 @@ function ChatMessageBody({ msg, isStaff }: { msg: Message; isStaff: boolean }) {
 function formatMessageTimestamps(ms: number) {
   const d = new Date(ms);
   return {
-    time: d.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }),
+    time: d.toLocaleTimeString("ja-JP", { timeZone: "Asia/Tokyo", hour: "2-digit", minute: "2-digit" }),
     datetime: d.toLocaleString("ja-JP", {
+      timeZone: "Asia/Tokyo",
       year: "numeric",
       month: "2-digit",
       day: "2-digit",
       hour: "2-digit",
       minute: "2-digit",
     }),
-    date_key: d.toISOString().slice(0, 10),
+    date_key: d.toLocaleDateString("ja-JP", {
+      timeZone: "Asia/Tokyo",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).replace(/\//g, "-"),
     timestamp_ms: ms,
   };
 }
@@ -217,6 +223,7 @@ function dateKeyToLabel(dateKey: string) {
   const [y, m, d] = dateKey.split("-").map(Number);
   if (!y || !m || !d) return dateKey;
   return new Date(y, m - 1, d).toLocaleDateString("ja-JP", {
+    timeZone: "Asia/Tokyo",
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/app/api/chats/[id]/messages/route.ts
+++ b/app/api/chats/[id]/messages/route.ts
@@ -152,8 +152,14 @@ export async function GET(
       const tsRaw = msg.timestamp ?? msg.created_timestamp ?? msg.time;
       const ms = shopeeMessageTimeToMs(tsRaw);
       const sec = ms / 1000;
-      const dateKey = new Date(ms).toISOString().slice(0, 10);
+      const dateKey = new Date(ms).toLocaleDateString("ja-JP", {
+        timeZone: "Asia/Tokyo",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).replace(/\//g, "-");
       const datetime = new Date(ms).toLocaleString("ja-JP", {
+        timeZone: "Asia/Tokyo",
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
@@ -209,6 +215,7 @@ export async function GET(
         order_url,
         item_url,
         time: new Date(ms).toLocaleTimeString("ja-JP", {
+          timeZone: "Asia/Tokyo",
           hour: "2-digit",
           minute: "2-digit",
         }),

--- a/app/api/chats/route.ts
+++ b/app/api/chats/route.ts
@@ -127,11 +127,13 @@ export async function GET(request: NextRequest) {
         lastMessage: conv.last_message,
         product: "—",
         date: elapsedBase.toLocaleDateString("ja-JP", {
+          timeZone: "Asia/Tokyo",
           year: "numeric",
           month: "2-digit",
           day: "2-digit",
         }),
         time: elapsedBase.toLocaleTimeString("ja-JP", {
+          timeZone: "Asia/Tokyo",
           hour: "2-digit",
           minute: "2-digit",
         }),


### PR DESCRIPTION
Vercel runs in UTC, so toLocaleString("ja-JP") without a timeZone option produced UTC times — 9 hours behind JST. Locally (Asia/Tokyo) the same calls returned correct JST times, causing a discrepancy between environments.

Fix: add timeZone: "Asia/Tokyo" to every toLocaleString / toLocaleTimeString / toLocaleDateString call in:
- GET /api/chats (date, time columns)
- GET /api/chats/[id]/messages (dateKey, datetime, time fields)
- chats/[id]/page.tsx formatMessageTimestamps + dateKeyToLabel

Also replace toISOString().slice(0,10) for dateKey with toLocaleDateString(timeZone:"Asia/Tokyo") so the date separator in the chat detail view uses JST date, not UTC date.